### PR TITLE
Fix: Display PIN on screen during pairing with Sunshine

### DIFF
--- a/src/n3ds_main.cpp
+++ b/src/n3ds_main.cpp
@@ -598,12 +598,22 @@ int main_loop(int argc, char *argv[]) {
                 }
                 printf("Please enter the following PIN on the target PC:\n%s\n",
                        pin);
-                fflush(stdout);
+                
+                // Actually display the PIN on screen by swapping buffers
+                gfxSwapBuffers();
+                gfxFlushBuffers();
+                gspWaitForVBlank();
+                
                 if (gs_pair(&server, &pin[0]) != GS_OK) {
                     printf("Failed to pair to server: %s\n", gs_error);
                 } else {
                     printf("Succesfully paired\n");
+                    // Display success message before breaking
+                    gfxSwapBuffers();
+                    gfxFlushBuffers();
+                    gspWaitForVBlank();
                     add_pair_address(config.address);
+                    wait_for_button();
                     break;
                 }
             } else if (strcmp("stream settings", config.action) == 0) {


### PR DESCRIPTION
## Summary
Fixes a bug where the 3DS client doesn't display the pairing PIN on screen when connecting to Sunshine hosts, making pairing impossible.

## Issue Description
Multiple users reported in Discord that no PIN appears on the 3DS screen during pairing with Sunshine, resulting in "not authorized" errors. Quote from Discord:
> "trying to connect to sunshine but the 3ds doesnt give me a pin to enter"

**This is a bug in Moonlight Embedded** (specifically the 3DS port), not a firewall/configuration issue. The PIN was being generated correctly but never rendered to the screen.

## Root Cause
The pairing code prints the PIN using `printf()` but never calls the required 3DS framebuffer swap functions (`gfxSwapBuffers()`, `gfxFlushBuffers()`, `gspWaitForVBlank()`) to actually display it. Every other part of the UI correctly calls these functions after printing (see lines 76-77, 130-132), but the pairing flow was missing them.

## Changes
// After printing the PIN (line 601-605):
+ // Actually display the PIN on screen by swapping buffers
+ gfxSwapBuffers();
+ gfxFlushBuffers();
+ gspWaitForVBlank();

// After successful pairing (line 611-617):
+ // Display success message before breaking
+ gfxSwapBuffers();
+ gfxFlushBuffers();
+ gspWaitForVBlank();
+ wait_for_button();  // So user can see confirmation## Testing
- [x] Code compiles without errors
- [x] Follows existing code style and patterns
- [x] Only changes necessary lines (11 lines added, 1 removed)
- [ ] Hardware testing (no 3DS available, requesting community testing)

## Files Changed
- `src/n3ds_main.cpp` - Lines 601-617 (pairing action handler)

This fix follows the exact same pattern already used throughout the codebase for displaying console output on the 3DS.

Testing:
[x] Code compiles without errors
[x] Follows existing code style and patterns
[x] Only changes necessary lines (11 lines added, 1 removed)
[ ] Hardware testing (no 3DS available, requesting community testing)


Files Changed:
- src/n3ds_main.cpp - Lines 601-617 (pairing action handler)

This fix follows the exact pattern already used throughout the codebase for displaying console output on the 3DS.