### PR TITLE
Add logic for streaming without video

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -17,21 +17,14 @@
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
+#include "config.hpp"
 #include "audio/audio.h"
 #include "system/pair_record.hpp"
 #include "util.h"
 
+#include <cstring>
+#include <fstream>
 #include <getopt.h>
-#include <limits.h>
-#include <pwd.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/types.h>
-#include <unistd.h>
-
-extern ssize_t getline(char **buf, size_t *bufsiz, FILE *fp);
 
 #define MOONLIGHT_PATH "/moonlight"
 #define USER_PATHS "."
@@ -55,7 +48,7 @@ static struct option long_options[] = {
     {"quitappafter", required_argument, NULL, '1'},
     {"viewonly", required_argument, NULL, '2'},
     {"port", required_argument, NULL, '6'},
-    {"hwdecode", required_argument, NULL, '8'},
+    {"video_decoder", required_argument, NULL, '8'},
     {"motion_controls", required_argument, NULL, 'e'},
     {"swapfacebuttons", required_argument, NULL, 'A'},
     {"swaptriggersandshoulders", required_argument, NULL, 'B'},
@@ -104,7 +97,11 @@ void parse_argument(int c, char *value, PCONFIGURATION config) {
         config->port = atoi(value);
         break;
     case '8':
-        config->hwdecode = ((value != NULL) && (strcmp(value, "true") == 0));
+        if (value == NULL) {
+            config->video_decoder = VIDEO_DECODER_TYPE::HARDWARE_VIDEO_DECODER;
+        } else {
+            config->video_decoder = (VIDEO_DECODER_TYPE)atoi(value);
+        }
         break;
     case 'A':
         config->swap_face_buttons =
@@ -131,19 +128,12 @@ void parse_argument(int c, char *value, PCONFIGURATION config) {
     }
 }
 
-bool config_file_parse(char *filename, PCONFIGURATION config) {
-    FILE *fd = fopen(filename, "r");
-    if (fd == NULL) {
-        fprintf(stderr, "Can't open configuration file: %s\n", filename);
-        return false;
-    }
-
-    char *line = NULL;
-    size_t len = 0;
-
-    while (getline(&line, &len, fd) != -1) {
+bool config_file_parse(PCONFIGURATION config) {
+    std::ifstream config_file(MOONLIGHT_3DS_PATH "/moonlight.conf");
+    std::string line;
+    while (std::getline(config_file, line)) {
         char *key = NULL, *value = NULL;
-        if (sscanf(line, "%ms = %m[^\n]", &key, &value) == 2) {
+        if (sscanf(line.c_str(), "%ms = %m[^\n]", &key, &value) == 2) {
             if (strcmp(key, "address") == 0) {
                 config->address = value;
             } else {
@@ -177,7 +167,7 @@ void config_save(char *filename, PCONFIGURATION config) {
     write_config_bool(fd, "localaudio", config->localaudio);
     write_config_bool(fd, "quitappafter", config->quitappafter);
     write_config_bool(fd, "viewonly", config->viewonly);
-    write_config_bool(fd, "hwdecode", config->hwdecode);
+    write_config_int(fd, "video_decoder", config->video_decoder);
     write_config_bool(fd, "swapfacebuttons", config->swap_face_buttons);
     write_config_bool(fd, "swaptriggersandshoulders",
                       config->swap_triggers_and_shoulders);
@@ -219,15 +209,13 @@ void config_parse(int argc, char *argv[], PCONFIGURATION config) {
     config->stream.height = 480;
     config->stream.fps = 60;
     config->stream.encryptionFlags = ENCFLG_NONE;
-    config->hwdecode = true;
+    config->video_decoder = VIDEO_DECODER_TYPE::HARDWARE_VIDEO_DECODER;
     config->motion_controls = false;
     config->swap_face_buttons = false;
     config->swap_triggers_and_shoulders = false;
     config->use_triggers_for_mouse = false;
 
-    char *config_file = (char *)MOONLIGHT_3DS_PATH "/moonlight.conf";
-    if (config_file)
-        config_file_parse(config_file, config);
+    config_file_parse(config);
 
     if (config->stream.bitrate == -1) {
         // This table prefers 16:10 resolutions because they are

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -25,9 +25,11 @@
 
 #define MAX_INPUTS 6
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+enum VIDEO_DECODER_TYPE {
+    HARDWARE_VIDEO_DECODER = 0,
+    SOFTWARE_VIDEO_DECODER,
+    DISABLE_VIDEO_DECODER
+};
 
 typedef struct _CONFIGURATION {
     STREAM_CONFIGURATION stream;
@@ -50,7 +52,7 @@ typedef struct _CONFIGURATION {
     bool hdr;
     int pin;
     unsigned short port;
-    bool hwdecode;
+    VIDEO_DECODER_TYPE video_decoder;
     bool motion_controls;
     bool swap_face_buttons;
     bool swap_triggers_and_shoulders;
@@ -61,7 +63,3 @@ bool config_file_parse(char *filename, PCONFIGURATION config);
 void config_parse(int argc, char *argv[], PCONFIGURATION config);
 void parse_argument(int c, char *value, PCONFIGURATION config);
 void config_save(char *filename, PCONFIGURATION config);
-
-#ifdef __cplusplus
-}
-#endif

--- a/src/n3ds_main.cpp
+++ b/src/n3ds_main.cpp
@@ -18,7 +18,7 @@
  */
 
 #include "audio/audio.h"
-#include "config.h"
+#include "config.hpp"
 #include "input/n3ds_input.hpp"
 #include "system/dispatcher.hpp"
 #include "system/n3ds_connection.hpp"
@@ -188,6 +188,21 @@ static std::string prompt_for_address() {
     return addr_string;
 }
 
+static VIDEO_DECODER_TYPE
+prompt_for_video_decoder(VIDEO_DECODER_TYPE default_val) {
+    std::vector<std::string> decoders = {
+        "hardware (fast, *new* 3DS only)",
+        "software (slow)",
+        "disable video",
+    };
+    int idx = console_selection_prompt("Select a video option", decoders,
+                                       (int)default_val);
+    if (idx < 0) {
+        return default_val;
+    }
+    return (VIDEO_DECODER_TYPE)idx;
+}
+
 static bool prompt_for_boolean(std::string prompt, bool default_val) {
     std::vector<std::string> options = {
         "true",
@@ -227,7 +242,7 @@ static void prompt_for_stream_settings(PCONFIGURATION config) {
         "localaudio",
         "quitappafter",
         "viewonly",
-        "hwdecode",
+        "video_decoder",
         "swapfacebuttons",
         "swaptriggersandshoulders",
         "usetriggersformouse",
@@ -279,9 +294,9 @@ static void prompt_for_stream_settings(PCONFIGURATION config) {
         } else if ("viewonly" == setting_names[idx]) {
             config->viewonly = prompt_for_boolean("Disable controller input",
                                                   config->viewonly);
-        } else if ("hwdecode" == setting_names[idx]) {
-            config->hwdecode = prompt_for_boolean("Use hardware video decoder",
-                                                  config->hwdecode);
+        } else if ("video_decoder" == setting_names[idx]) {
+            config->video_decoder =
+                prompt_for_video_decoder(config->video_decoder);
         } else if ("swapfacebuttons" == setting_names[idx]) {
             config->swap_face_buttons = prompt_for_boolean(
                 "Swaps A/B and X/Y to match Xbox controller layout",
@@ -426,18 +441,27 @@ static void stream(PSERVER_DATA server, PCONFIGURATION config, int appId,
 
     AUDIO_RENDERER_CALLBACKS *audio_callbacks =
         config->localaudio ? &audio_callbacks_mock : &audio_callbacks_n3ds;
-    PDECODER_RENDERER_CALLBACKS video_callbacks =
-        config->hwdecode ? &decoder_callbacks_n3ds_mvd
-                         : &decoder_callbacks_n3ds;
+
+    PDECODER_RENDERER_CALLBACKS video_callbacks = &decoder_callbacks_mock;
+    switch (config->video_decoder) {
+    case (VIDEO_DECODER_TYPE::HARDWARE_VIDEO_DECODER):
+        video_callbacks = &decoder_callbacks_n3ds_mvd;
+        break;
+    case (VIDEO_DECODER_TYPE::SOFTWARE_VIDEO_DECODER):
+        video_callbacks = &decoder_callbacks_n3ds;
+        break;
+    default:
+        break;
+    }
 
     printf(
         "Loading...\nStream %dx%d, %dfps, %dkbps, sops=%d, localaudio=%d, quitappafter=%d,\
- viewonly=%d, encryption=%x, hwdecode=%d, swapfacebuttons=%d, swaptriggersandshoulders=%d,\
+ viewonly=%d, encryption=%x, video_decoder=%d, swapfacebuttons=%d, swaptriggersandshoulders=%d,\
  usetriggersformouse=%d, motion_controls=%d\n",
         config->stream.width, config->stream.height, config->stream.fps,
         config->stream.bitrate, config->sops, config->localaudio,
         config->quitappafter, config->viewonly, config->stream.encryptionFlags,
-        config->hwdecode, config->swap_face_buttons,
+        config->video_decoder, config->swap_face_buttons,
         config->swap_triggers_and_shoulders, config->use_triggers_for_mouse,
         config->motion_controls);
 

--- a/src/video/n3ds_video_mock.cpp
+++ b/src/video/n3ds_video_mock.cpp
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Moonlight Embedded.
+ *
+ * Copyright (C) 2015 Iwan Timmer
+ *
+ * Moonlight is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moonlight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "video.hpp"
+#include <stdexcept>
+
+static std::unique_ptr<MockVideoDecoder> instance = nullptr;
+
+MockVideoDecoder::MockVideoDecoder(int videoFormat, int width, int height,
+                                   int redrawRate, void *context, int drFlags)
+    : VideoDecoderBase(width, height) {}
+
+MockVideoDecoder::~MockVideoDecoder() = default;
+
+static int fakeDrSetup(int videoFormat, int width, int height, int redrawRate,
+                       void *context, int drFlags) {
+    try {
+        instance = std::make_unique<MockVideoDecoder>(
+            videoFormat, width, height, redrawRate, context, drFlags);
+        return 0;
+    } catch (const std::exception &e) {
+        fprintf(stderr, "Failed to initialize N3DS soft decoder: %s\n",
+                e.what());
+        return -1;
+    }
+}
+static void fakeDrStart(void) {}
+static void fakeDrStop(void) {}
+static void fakeDrCleanup(void) { instance = nullptr; }
+static int fakeDrSubmitDecodeUnit(PDECODE_UNIT decodeUnit) { return DR_OK; }
+
+DECODER_RENDERER_CALLBACKS decoder_callbacks_mock = {
+    .setup = fakeDrSetup,
+    .start = fakeDrStart,
+    .stop = fakeDrStop,
+    .cleanup = fakeDrCleanup,
+    .submitDecodeUnit = fakeDrSubmitDecodeUnit,
+};

--- a/src/video/video.hpp
+++ b/src/video/video.hpp
@@ -61,6 +61,13 @@ class VideoDecoderBase : public ISubscriber {
     ThreadLock renderer_lock;
 };
 
+class MockVideoDecoder : public VideoDecoderBase {
+  public:
+    MockVideoDecoder(int videoFormat, int width, int height, int redrawRate,
+                     void *context, int drFlags);
+    ~MockVideoDecoder();
+};
+
 class SoftVideoDecoder : public VideoDecoderBase {
   public:
     SoftVideoDecoder(int videoFormat, int width, int height, int redrawRate,
@@ -98,3 +105,4 @@ class MvdDecoder : public VideoDecoderBase {
 
 extern DECODER_RENDERER_CALLBACKS decoder_callbacks_n3ds;
 extern DECODER_RENDERER_CALLBACKS decoder_callbacks_n3ds_mvd;
+extern DECODER_RENDERER_CALLBACKS decoder_callbacks_mock;


### PR DESCRIPTION
## Changelog

- Adds a "mock video decoder" implementation
- Makes the config files C++
- Replaces "hwdecode" with a video_decoder option
- Adds an enum defining video decoding options

## Issues

- https://github.com/zoeyjodon/moonlight-N3DS/issues/56
- https://github.com/zoeyjodon/moonlight-N3DS/issues/92
- https://github.com/zoeyjodon/moonlight-N3DS/issues/95
- https://github.com/zoeyjodon/moonlight-N3DS/issues/103